### PR TITLE
Support private packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ All check list is passed, exit status will be `0`.
 - [x] Check that the package's name is valid
     - [validate-npm-package-name](https://github.com/npm/validate-npm-package-name "validate-npm-package-name")
 - [x] Check that the package is not `private:true`
-- [x] Check that `pacakge@version` is already published in npm registry
+- [x] Check that `package@version` is already published in npm registry
 
 ## Install
 

--- a/lib/can-npm-publish.js
+++ b/lib/can-npm-publish.js
@@ -37,9 +37,9 @@ const checkPrivateField = packagePath => {
  * @param packageName
  * @returns {Promise}
  */
-const viewPackage = name => {
+const viewPackage = packageName => {
     return new Promise((resolve, reject) => {
-        const view = spawn("npm", ["view", name, "versions", "--json"]);
+        const view = spawn("npm", ["view", packageName, "versions", "--json"]);
         let result = "";
 
         view.stdout.on("data", data => {

--- a/lib/can-npm-publish.js
+++ b/lib/can-npm-publish.js
@@ -1,6 +1,6 @@
 // MIT © 2018 azu
 "use strict";
-const fetch = require("node-fetch");
+const spawn = require("child_process").spawn;
 const readPkg = require("read-pkg");
 const validatePkgName = require("validate-npm-package-name");
 /**
@@ -31,6 +31,36 @@ const checkPrivateField = packagePath => {
     });
 };
 
+/**
+ * Return Promise which resolves with an array of version numbers for the package
+ * or rejects if anything failed
+ * @param packageName
+ * @returns {Promise}
+ */
+const viewPackage = name => {
+    return new Promise((resolve, reject) => {
+        const view = spawn("npm", ["view", name, "versions", "--json"]);
+        let result = "";
+
+        view.stdout.on("data", data => {
+            result += data.toString();
+        });
+
+        view.stderr.on("data", err => {
+            console.error(err.toString());
+        });
+
+        view.on("close", code => {
+            if (code > 0) {
+                reject();
+                return;
+            }
+
+            resolve(JSON.parse(result));
+        });
+    });
+};
+
 const checkAlreadyPublish = packagePath => {
     return readPkg(packagePath).then(pkg => {
         const name = pkg["name"];
@@ -41,33 +71,12 @@ const checkAlreadyPublish = packagePath => {
         if (version === undefined) {
             return Promise.reject(new Error("This package has not `version`."));
         }
-        // https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#getpackageversion
-        // @scope/name => @scope%2Fname
-        const encodedName = name.replace(/\//g, "%2F");
-        return fetch(`https://registry.npmjs.com/${encodedName}`)
-            .then(response => {
-                if (response.status === 404) {
-                    // not published yet
-                    return {
-                        versions: []
-                    };
-                }
-                if (!response.ok) {
-                    return Promise.reject(new Error(response.statusText));
-                }
-                return response.json();
-            })
-            .then(json => {
-                if (json.error) {
-                    // {"error":"version not found: 18.0.0"}
-                    return Promise.reject(new Error(json.error));
-                }
-                const versions = json["versions"];
-                if (versions[version]) {
-                    return Promise.reject(new Error(`${name}@${version} is already published`));
-                }
-                return;
-            });
+        return viewPackage(name).then(versions => {
+            if (versions.includes(version)) {
+                return Promise.reject(new Error(`${name}@${version} is already published`));
+            }
+            return;
+        });
     });
 };
 const canNpmPublish = packagePath => {

--- a/lib/can-npm-publish.js
+++ b/lib/can-npm-publish.js
@@ -41,18 +41,19 @@ const viewPackage = packageName => {
     return new Promise((resolve, reject) => {
         const view = spawn("npm", ["view", packageName, "versions", "--json"]);
         let result = "";
+        let errorResult = "";
 
         view.stdout.on("data", data => {
             result += data.toString();
         });
 
         view.stderr.on("data", err => {
-            console.error(err.toString());
+            errorResult += err.toString();
         });
 
         view.on("close", code => {
             if (code > 0) {
-                reject();
+                reject(new Error(errorResult));
                 return;
             }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "meow": "^4.0.0",
-    "node-fetch": "^1.7.3",
     "read-pkg": "^3.0.0",
     "validate-npm-package-name": "^3.0.0"
   },


### PR DESCRIPTION
In case your packages require you to login to npm using their cli, `can-npm-publish` won't see them (instead getting a 404 with `node-fetch`). I changed the check to use `npm view` as suggested in #1