### PR TITLE
Windows compatible spawn with 'cross-spawn'

### DIFF
--- a/lib/can-npm-publish.js
+++ b/lib/can-npm-publish.js
@@ -1,6 +1,6 @@
 // MIT © 2018 azu
 "use strict";
-const spawn = require("child_process").spawn;
+const spawn = require("cross-spawn");
 const readPkg = require("read-pkg");
 const validatePkgName = require("validate-npm-package-name");
 /**

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "postcommit": "git reset"
   },
   "dependencies": {
+    "cross-spawn": "^6.0.5",
     "meow": "^4.0.0",
     "read-pkg": "^3.0.0",
     "validate-npm-package-name": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,6 +163,16 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -621,6 +631,10 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
@@ -724,7 +738,7 @@ path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -802,7 +816,7 @@ rxjs@^5.4.2:
   dependencies:
     symbol-observable "1.0.1"
 
-"semver@2 || 3 || 4 || 5":
+"semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 


### PR DESCRIPTION
I encountered issues with child_process.spawn on Windows.

https://stackoverflow.com/a/35561971

This adds [cross-spawn](https://www.npmjs.com/package/cross-spawn) as a dependency which works well on Windows.