### PR TITLE
Add support for registry definition in package.json publishConfig

### DIFF
--- a/lib/can-npm-publish.js
+++ b/lib/can-npm-publish.js
@@ -39,7 +39,8 @@ const checkPrivateField = packagePath => {
  */
 const viewPackage = (packageName, registry) => {
     return new Promise((resolve, reject) => {
-        const view = spawn("npm", ["view", packageName, "versions", "--json", registry && `--registry=${registry}`]);
+        const registryArgs = registry ? ["--registry", registry] : [];
+        const view = spawn("npm", ["view", packageName, "versions", "--json"].concat(registryArgs));
         let result = "";
         let errorResult = "";
 

--- a/lib/can-npm-publish.js
+++ b/lib/can-npm-publish.js
@@ -35,6 +35,7 @@ const checkPrivateField = packagePath => {
  * Return Promise which resolves with an array of version numbers for the package
  * or rejects if anything failed
  * @param packageName
+ * @param registry
  * @returns {Promise}
  */
 const viewPackage = (packageName, registry) => {

--- a/lib/can-npm-publish.js
+++ b/lib/can-npm-publish.js
@@ -37,9 +37,9 @@ const checkPrivateField = packagePath => {
  * @param packageName
  * @returns {Promise}
  */
-const viewPackage = packageName => {
+const viewPackage = (packageName, registry) => {
     return new Promise((resolve, reject) => {
-        const view = spawn("npm", ["view", packageName, "versions", "--json"]);
+        const view = spawn("npm", ["view", packageName, "versions", "--json", registry && `--registry=${registry}`]);
         let result = "";
         let errorResult = "";
 
@@ -66,13 +66,15 @@ const checkAlreadyPublish = packagePath => {
     return readPkg(packagePath).then(pkg => {
         const name = pkg["name"];
         const version = pkg["version"];
+        const publishConfig = pkg["publishConfig"];
+        const registry = publishConfig && publishConfig["registry"];
         if (name === undefined) {
             return Promise.reject(new Error("This package has not `name`."));
         }
         if (version === undefined) {
             return Promise.reject(new Error("This package has not `version`."));
         }
-        return viewPackage(name).then(versions => {
+        return viewPackage(name, registry).then(versions => {
             if (versions.includes(version)) {
                 return Promise.reject(new Error(`${name}@${version} is already published`));
             }

--- a/test/can-npm-publish-test.js
+++ b/test/can-npm-publish-test.js
@@ -21,6 +21,14 @@ describe("can-npm-publish", () => {
             assert.ok(/is already published/.test(error.message));
         });
     });
+    it("should be rejected, it is already published to yarnpkg registry", () => {
+        return canNpmPublish(path.join(__dirname, "fixtures/already-published-registry.json")).then(
+            shouldNotCalled,
+            error => {
+                assert.ok(/is already published/.test(error.message));
+            }
+        );
+    });
     it("should be rejected, it is already published scoped package", () => {
         return canNpmPublish(path.join(__dirname, "fixtures/scoped-package.json")).then(shouldNotCalled, error => {
             assert.ok(/is already published/.test(error.message));
@@ -28,5 +36,8 @@ describe("can-npm-publish", () => {
     });
     it("should be resolve, it is not published yet", () => {
         return canNpmPublish(path.join(__dirname, "fixtures/not-published-yet.json"));
+    });
+    it("should be resolve, it is not published yet to yarnpkg registry", () => {
+        return canNpmPublish(path.join(__dirname, "fixtures/not-published-yet-registry.json"));
     });
 });

--- a/test/fixtures/already-published-registry.json
+++ b/test/fixtures/already-published-registry.json
@@ -1,0 +1,88 @@
+{
+    "name": "almin",
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/almin/almin.git"
+    },
+    "author": "azu",
+    "email": "azuciao@gmail.com",
+    "homepage": "https://github.com/almin/almin",
+    "license": "MIT",
+    "files": [
+      "src/",
+      "lib/src"
+    ],
+    "bugs": {
+      "url": "https://github.com/almin/almin/issues"
+    },
+    "version": "0.15.2",
+    "description": "Client-side DDD/CQRS for JavaScript.",
+    "main": "lib/src/index.js",
+    "types": "lib/src/index.d.ts",
+    "directories": {
+      "test": "test"
+    },
+    "scripts": {
+      "clean": "rimraf lib/",
+      "build": "npm-run-all -s build:src build:lib",
+      "build:src": "tsc --project .",
+      "build:lib": "npm-run-all -p build:lib:*",
+      "build:lib:cp_type_def": "cpx type-definitions/**/*.js.flow lib/src/ --preserve",
+      "build:test": "tsc --project test/",
+      "lint": "npm-run-all -p lint:*",
+      "lint:fix": "npm-run-all -p lint:*:fix",
+      "lint:js": "eslint --config ../../.eslintrc.json --cache test/",
+      "lint:js:fix": "eslint --fix --config ../../.eslintrc.json --cache test/",
+      "test": "run-s lint test:js",
+      "test:js": "cross-env NODE_ENV=development mocha \"test/**/*.{js,ts}\"",
+      "test:saucelabs": "npm run build:test && zuul -- out/test/*-test.js",
+      "test:browser": "npm run build:test && zuul --local 8080 --ui mocha-bdd -- out/test/*-test.js",
+      "posttest": "npm run clean",
+      "presize": "npm-run-all -s clean build",
+      "size": "size-limit",
+      "ci": "npm test && npm run size",
+      "prepublish": "npm run --if-present build"
+    },
+    "size-limit": [
+      {
+        "path": "lib/src/index.js",
+        "limit": "15 KB"
+      }
+    ],
+    "keywords": [
+      "flux",
+      "cqrs",
+      "ddd",
+      "architecture",
+      "aluminium"
+    ],
+    "devDependencies": {
+      "@types/mocha": "^2.2.41",
+      "@types/node": "^9.3.0",
+      "@types/sinon": "^4.1.3",
+      "cpx": "^1.5.0",
+      "cross-env": "^5.0.1",
+      "env-development": "^1.0.2",
+      "eslint": "^4.2.0",
+      "function.name": "^1.0.2",
+      "mocha": "^3.4.2",
+      "npm-run-all": "^4.0.2",
+      "power-assert": "^1.4.4",
+      "rimraf": "^2.6.2",
+      "sinon": "^2.3.8",
+      "size-limit": "^0.14.0",
+      "source-map-support": "^0.4.15",
+      "ts-node": "^4.1.0",
+      "ts-node-test-register": "^1.0.1",
+      "typescript": "~2.6.2",
+      "zuul": "^3.10.1"
+    },
+    "dependencies": {
+      "map-like": "^2.0.0",
+      "shallow-equal-object": "^1.0.1"
+    },
+    "publishConfig": {
+      "registry": "https://registry.yarnpkg.com"
+    }
+  }
+  

--- a/test/fixtures/not-published-yet-registry.json
+++ b/test/fixtures/not-published-yet-registry.json
@@ -1,0 +1,65 @@
+{
+    "name": "can-npm-publish",
+    "version": "0.0.0",
+    "description": "A command line tool that check to see if `npm publish` is possible.",
+    "keywords": [
+      "cli",
+      "npm",
+      "publish"
+    ],
+    "homepage": "https://github.com/azu/can-npm-publish",
+    "bugs": {
+      "url": "https://github.com/azu/can-npm-publish/issues"
+    },
+    "license": "MIT",
+    "author": "azu",
+    "files": [
+      "bin/",
+      "lib/",
+      "src/"
+    ],
+    "main": "lib/can-npm-publish.js",
+    "bin": {
+      "can-npm-publish": "./bin/cmd.js"
+    },
+    "directories": {
+      "lib": "lib",
+      "test": "test"
+    },
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/azu/can-npm-publish.git"
+    },
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1",
+      "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+      "precommit": "lint-staged",
+      "postcommit": "git reset"
+    },
+    "dependencies": {
+      "meow": "^4.0.0",
+      "node-fetch": "^1.7.3",
+      "read-pkg": "^3.0.0"
+    },
+    "devDependencies": {
+      "husky": "^0.14.3",
+      "lint-staged": "^6.0.1",
+      "mocha": "^5.0.0",
+      "prettier": "^1.10.2"
+    },
+    "prettier": {
+      "singleQuote": false,
+      "printWidth": 120,
+      "tabWidth": 4
+    },
+    "lint-staged": {
+      "*.{js,jsx,ts,tsx,css}": [
+        "prettier --write",
+        "git add"
+      ]
+    },
+    "publishConfig": {
+      "registry": "https://registry.yarnpkg.com"
+    }
+  }
+  


### PR DESCRIPTION
Currently if an alternative/private registry is defined in package.json publishConfig, npmjs.org registry will still be used.

This adds support by reading the registry field in package.json and passing it to `npm view` with the `--registry` argument.

Added tests using the Yarn registry as an alternative registry.