### PR TITLE
feat: show result json if debug mode

### DIFF
--- a/lib/can-npm-publish.js
+++ b/lib/can-npm-publish.js
@@ -65,6 +65,10 @@ const viewPackage = (packageName, registry) => {
         });
 
         view.on("close", code => {
+            if (process.env.DEBUG) {
+              console.log(result)
+            }
+
             const resultJSON = JSON.parse(result);
             if (resultJSON && resultJSON.error) {
                 // the package is not in the npm registry => can publish


### PR DESCRIPTION
If received unexpected format `result` from npm, I'd like to see log with DEBUG env.