### PR TITLE
Output errors to stderr

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -38,7 +38,7 @@ canNpmPublish(cli.input[0], {
     })
     .catch(error => {
         if (cli.flags.verbose) {
-            console.log(error.message);
+            console.error(error.message);
         }
         process.exit(1);
     });

--- a/lib/can-npm-publish.js
+++ b/lib/can-npm-publish.js
@@ -23,7 +23,7 @@ const checkPkgName = (packagePath, options) => {
             }
             // warning is ignored by default
             if (options.verbose && result.warnings) {
-                console.log(result.warnings.join("\n"));
+                console.warn(result.warnings.join("\n"));
             }
         }
     });

--- a/test/can-npm-publish-bin-test.js
+++ b/test/can-npm-publish-bin-test.js
@@ -1,0 +1,41 @@
+const { spawn } = require("child_process");
+const assert = require("assert");
+const path = require("path");
+
+// Path to the executable script
+const binPath = path.join(__dirname, "../bin/cmd.js");
+
+const shouldNotCalled = () => {
+    throw new Error("SHOULD NOT CALLED");
+};
+
+describe("can-npm-publish bin", () => {
+    it("should return 0, it can publish", done => {
+        const bin = spawn("node", [binPath, path.join(__dirname, "fixtures/not-published-yet.json")]);
+
+        // Finish the test when the executable finishes and returns 0
+        bin.on("close", exit_code => {
+            assert.ok(exit_code === 0);
+            done();
+        });
+    });
+    it("should return 1, it can't publish", done => {
+        const bin = spawn("node", [binPath, path.join(__dirname, "fixtures/already-published.json")]);
+
+        // Finish the test when the executable finishes and returns 1
+        bin.on("close", exit_code => {
+            assert.ok(exit_code === 1);
+            done();
+        });
+    });
+    it("should send errors to stderr when verbose, it can't publish", done => {
+        const bin = spawn("node", [binPath, path.join(__dirname, "fixtures/already-published.json"), "--verbose"]);
+
+        // Finish the test and stop the executable when it outputs to stderr
+        bin.stderr.on("data", data => {
+            assert.ok(/almin@0.15.2 is already published/.test(data));
+            bin.kill();
+            done();
+        });
+    });
+});

--- a/test/can-npm-publish-test.js
+++ b/test/can-npm-publish-test.js
@@ -40,4 +40,22 @@ describe("can-npm-publish", () => {
     it("should be resolve, it is not published yet to yarnpkg registry", () => {
         return canNpmPublish(path.join(__dirname, "fixtures/not-published-yet-registry.json"));
     });
+    it("should warn when verbose, it is legacy name", () => {
+        const stderrWrite = process.stderr.write.bind(process.stderr);
+        let stderrOutput = "";
+
+        // Capture output to stderr in `stderrOutput`
+        process.stderr.write = (chunk, encoding, callback) => {
+            if (typeof chunk === "string") {
+                stderrOutput += chunk;
+            }
+        };
+
+        return canNpmPublish(path.join(__dirname, "fixtures/legacy-name.json"), { verbose: true }).then(() => {
+            // Restore stderr to normal
+            process.stderr.write = stderrWrite;
+
+            assert.ok(/name can no longer contain capital letters/.test(stderrOutput));
+        }, shouldNotCalled);
+    });
 });

--- a/test/fixtures/legacy-name.json
+++ b/test/fixtures/legacy-name.json
@@ -1,0 +1,5 @@
+{
+  "private": false,
+  "name": "lEgAcY-nAmE",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
This commit outputs CLI errors to stderr, and outputs legacy package name warnings to stderr as well to close out #4 

The outputs are covered by tests, including the CLI interface