### PR TITLE
fix: typo (pacakge => package)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install with [npm](https://www.npmjs.com/):
 ## Usage
 
     Usage
-      $ can-npm-publish [directory|pacakge.json path]
+      $ can-npm-publish [directory|package.json path]
 
     Options
       --verbose  show detail of errors

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -5,7 +5,7 @@ const canNpmPublish = require("../lib/can-npm-publish").canNpmPublish;
 const cli = meow(
     `
     Usage
-      $ can-npm-publish [directory|pacakge.json path]
+      $ can-npm-publish [directory|package.json path]
 
     Options
       --verbose  show detail of errors


### PR DESCRIPTION
## 概要
`pacakge.json` となっている箇所を `package.json` に修正

## 影響範囲
コマンドのヘルプ表示とREADMEのみ
