### PR TITLE
fix: error on isError due to changes of output format of `npm view`

### DIFF
--- a/lib/can-npm-publish.js
+++ b/lib/can-npm-publish.js
@@ -108,7 +108,7 @@ const viewPackage = (packageName, registry, options) => {
             };
         };
         const isError = (json) => {
-            return json && "error" in json;
+            return json && typeof json !== "string" && "error" in json;
         };
         const is404Error = (json) => {
             return isError(json) && json.error.code === "E404";


### PR DESCRIPTION
# Overview

The Following error occurred when the specific condition:

```
% npx can-npm-publish --verbose
`npm view` command's exit code: 0
`npm view` stdoutJSON 0.0.1
`npm view` stderrJSON null
/can-npm-publish/lib/can-npm-publish.js:111
            return json && "error" in json;
                                   ^

TypeError: Cannot use 'in' operator to search for 'error' in 0.0.1
    at isError (/can-npm-publish/lib/can-npm-publish.js:111:36)
    at is404Error (/can-npm-publish/lib/can-npm-publish.js:114:20)
    at ChildProcess.<anonymous> (/can-npm-publish/lib/can-npm-publish.js:148:17)
    at ChildProcess.emit (node:events:394:28)
    at maybeClose (node:internal/child_process:1064:16)
    at Socket.<anonymous> (node:internal/child_process:450:11)
    at Socket.emit (node:events:394:28)
    at Pipe.<anonymous> (node:net:672:12)
```

# Reproduce and conditions

In npm 7, the output format has been changed from array of single version like `[ "0.0.1" ]` to a single string like `"0.0.1"` when the package has only one version.

Conditions:
- The package only one published version 
- npm 7

The response format of `npm view PACKAGE_NAME --json` 

```
% npm view PACKAGE_NAME versions --json
"0.0.1"
```

In npm 6, the same command shows following output:

```
% npm view PACKAGE_NAME versions --json
[
  "0.0.1"
]
```